### PR TITLE
Fix ApplyVisaPage import error

### DIFF
--- a/client/app/apply/ApplyPageContent.js
+++ b/client/app/apply/ApplyPageContent.js
@@ -1,0 +1,1 @@
+export { default } from "./ApplyPageContent_new";


### PR DESCRIPTION
## Summary
- fix invalid element error by exporting the ApplyPageContent component

## Testing
- `npm run lint` *(fails: prompts for configuration)*
- `npm run build` *(fails: module not found errors)*

------
https://chatgpt.com/codex/tasks/task_e_684e52f4d028832baf0be4dff2c702fa