### PR TITLE
Refactor dashboard imports

### DIFF
--- a/client/app/dashboard/applications/page.js
+++ b/client/app/dashboard/applications/page.js
@@ -2,7 +2,7 @@
 
 import React, { useState } from "react";
 import { useQuery, useMutation } from "@apollo/client";
-import { GET_VISA_APPLICATIONS, GET_APPLICATION_MEMOS } from "../../src/lib/graphql/query/applications";
+import { GET_VISA_APPLICATIONS, GET_APPLICATION_MEMOS } from "@/lib/graphql/query/applications";
 import {
   UPDATE_APPLICATION_STATUS_MUTATION,
   SEND_EMAIL_MUTATION,
@@ -11,10 +11,10 @@ import {
   DELETE_MEMO_MUTATION,
   UPDATE_APPLICATION_INFO_MUTATION,
   DOWNLOAD_DOCUMENTS_MUTATION,
-} from "../../src/lib/graphql/mutation/applications";
-import { Card, CardContent } from "../../src/components/ui/card";
-import { Button } from "../../src/components/ui/button";
-import { Input } from "../../src/components/ui/input";
+} from "@/lib/graphql/mutation/applications";
+import { Card, CardContent } from "@/components/ui/card";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
 import { FileText, Search, Filter, Eye, Edit, CheckCircle, XCircle, Clock, AlertTriangle, Download, Send, User, Calendar, Globe, Phone, Mail } from "lucide-react";
 
 export default function ApplicationsManagement() {

--- a/client/app/dashboard/consultations/page.js
+++ b/client/app/dashboard/consultations/page.js
@@ -2,11 +2,11 @@
 
 import React, { useState } from "react";
 import { useQuery } from "@apollo/client";
-import { Card, CardContent } from "../../src/components/ui/card";
-import { Button } from "../../src/components/ui/button";
-import { Input } from "../../src/components/ui/input";
+import { Card, CardContent } from "@/components/ui/card";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
 import { MessageSquare, Phone, Search, Filter, Eye, Reply, CheckCircle, Clock, Star, User, Calendar, MessageCircle, Mail, Plus } from "lucide-react";
-import { GET_CONSULTATIONS } from "../../src/lib/graphql/query/consultations/index.js";
+import { GET_CONSULTATIONS } from "@/lib/graphql/query/consultations/index.js";
 
 export default function ConsultationsManagement() {
   const [searchTerm, setSearchTerm] = useState("");

--- a/client/app/dashboard/consultations/page_new.js
+++ b/client/app/dashboard/consultations/page_new.js
@@ -2,9 +2,9 @@
 
 import React, { useState } from 'react';
 import { useQuery, useMutation } from '@apollo/client';
-import { Card, CardContent, CardHeader, CardTitle } from '../../src/components/ui/card';
-import { Button } from '../../src/components/ui/button';
-import { Input } from '../../src/components/ui/input';
+import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
+import { Button } from '@/components/ui/button';
+import { Input } from '@/components/ui/input';
 import { 
   MessageSquare,
   Phone,
@@ -21,11 +21,11 @@ import {
   Mail,
   Plus
 } from 'lucide-react';
-import { GET_CONSULTATIONS } from '../../src/lib/graphql/query/consultations/index.js';
+import { GET_CONSULTATIONS } from '@/lib/graphql/query/consultations/index.js';
 import { 
   UPDATE_CONSULTATION_STATUS_MUTATION, 
   DELETE_CONSULTATION_MUTATION 
-} from '../../src/lib/graphql/mutation/consultations/index.js';
+} from '@/lib/graphql/mutation/consultations/index.js';
 
 export default function ConsultationsManagement() {
   const [searchTerm, setSearchTerm] = useState('');

--- a/client/app/dashboard/customer-preview/page.js
+++ b/client/app/dashboard/customer-preview/page.js
@@ -3,10 +3,10 @@
 
 import React, { useState } from 'react';
 import { useQuery } from '@apollo/client';
-import { GET_VISA_APPLICATIONS } from '../../src/lib/graphql';
-import { Card, CardContent, CardHeader, CardTitle } from '../../src/components/ui/card';
-import { Button } from '../../src/components/ui/button';
-import { Badge } from '../../src/components/ui/badge';
+import { GET_VISA_APPLICATIONS } from '@/lib/graphql';
+import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
+import { Button } from '@/components/ui/button';
+import { Badge } from '@/components/ui/badge';
 import {
   Eye,
   Settings,

--- a/client/app/dashboard/documents/page.js
+++ b/client/app/dashboard/documents/page.js
@@ -2,9 +2,9 @@
 'use client';
 
 import React, { useState } from 'react';
-import { Card, CardContent, CardHeader, CardTitle } from '../../src/components/ui/card';
-import { Button } from '../../src/components/ui/button';
-import { Input } from '../../src/components/ui/input';
+import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
+import { Button } from '@/components/ui/button';
+import { Input } from '@/components/ui/input';
 import { 
   FileText,
   Upload,

--- a/client/app/dashboard/documents/page_new.js
+++ b/client/app/dashboard/documents/page_new.js
@@ -8,17 +8,17 @@ import {
   Image, File, Trash2, Edit3, Calendar, User, FileCheck,
   Loader2, Plus, RefreshCw
 } from 'lucide-react';
-import { Card, CardContent, CardHeader, CardTitle } from '../../src/components/ui/card';
-import { Button } from '../../src/components/ui/button';
-import { Input } from '../../src/components/ui/input';
-import { Badge } from '../../src/components/ui/badge';
+import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
+import { Button } from '@/components/ui/button';
+import { Input } from '@/components/ui/input';
+import { Badge } from '@/components/ui/badge';
 import { 
   Select,
   SelectContent,
   SelectItem,
   SelectTrigger,
   SelectValue,
-} from '../../src/components/ui/select';
+} from '@/components/ui/select';
 import { 
   Dialog,
   DialogContent,
@@ -26,32 +26,32 @@ import {
   DialogFooter,
   DialogHeader,
   DialogTitle,
-} from '../../src/components/ui/dialog';
-import { Textarea } from '../../src/components/ui/textarea';
-import { Alert, AlertDescription } from '../../src/components/ui/alert';
-import { Tabs, TabsContent, TabsList, TabsTrigger } from '../../src/components/ui/tabs';
-import { Checkbox } from '../../src/components/ui/checkbox';
+} from '@/components/ui/dialog';
+import { Textarea } from '@/components/ui/textarea';
+import { Alert, AlertDescription } from '@/components/ui/alert';
+import { Tabs, TabsContent, TabsList, TabsTrigger } from '@/components/ui/tabs';
+import { Checkbox } from '@/components/ui/checkbox';
 import {
   DropdownMenu,
   DropdownMenuContent,
   DropdownMenuItem,
   DropdownMenuTrigger,
-} from '../../src/components/ui/dropdown-menu';
+} from '@/components/ui/dropdown-menu';
 
 // GraphQL imports
 import { 
   GET_DOCUMENTS, 
   GET_DOCUMENT_STATISTICS,
   GET_DOCUMENT_TYPES 
-} from '../../src/lib/graphql/query/documents';
+} from '@/lib/graphql/query/documents';
 import { 
   UPDATE_DOCUMENT_STATUS,
   BULK_UPDATE_DOCUMENT_STATUS,
   DELETE_DOCUMENT 
-} from '../../src/lib/graphql/mutation/documents';
+} from '@/lib/graphql/mutation/documents';
 
 // Components
-import FileUpload from '../../src/components/FileUpload';
+import FileUpload from '@/components/FileUpload';
 
 export default function DocumentsManagement() {
   const [searchTerm, setSearchTerm] = useState('');

--- a/client/app/dashboard/home/page.js
+++ b/client/app/dashboard/home/page.js
@@ -1,10 +1,10 @@
 import React, { useState } from "react";
 import { useQuery, useMutation } from "@apollo/client";
-import { GET_HOME_CONTENT, UPDATE_HOME_CONTENT } from "../../src/lib/graphql";
-import { Card, CardContent, CardHeader, CardTitle } from "../../src/components/ui/card";
-import { Button } from "../../src/components/ui/button";
-import { Input } from "../../src/components/ui/input";
-import { Textarea } from "../../src/components/ui/textarea";
+import { GET_HOME_CONTENT, UPDATE_HOME_CONTENT } from "@/lib/graphql";
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import { Textarea } from "@/components/ui/textarea";
 import { toast } from "react-hot-toast";
 
 export default function HomeContentManagement() {

--- a/client/app/dashboard/layout.js
+++ b/client/app/dashboard/layout.js
@@ -4,9 +4,9 @@ import React, { useEffect, useState } from "react";
 import { useRouter, usePathname } from "next/navigation";
 import { useQuery } from "@apollo/client";
 import { Toaster } from "react-hot-toast";
-import { GET_ADMIN_ME_QUERY } from "../../lib/graphql";
-import useSocket from "../src/hooks/useSocket";
-import NotificationCenter from "../src/components/NotificationCenter";
+import { GET_ADMIN_ME_QUERY } from "@/lib/graphql";
+import useSocket from "@/hooks/useSocket";
+import NotificationCenter from "@/components/NotificationCenter";
 import {
   LayoutDashboard,
   FileText,

--- a/client/app/dashboard/login/page.js
+++ b/client/app/dashboard/login/page.js
@@ -4,10 +4,10 @@
 import React, { useState, useEffect } from 'react';
 import { useMutation } from '@apollo/client';
 import { useRouter } from 'next/navigation';
-import { ADMIN_LOGIN_MUTATION } from '../../../lib/graphql';
-import { Button } from '../../src/components/ui/button';
-import { Input } from '../../src/components/ui/input';
-import { Card, CardContent, CardHeader, CardTitle } from '../../src/components/ui/card';
+import { ADMIN_LOGIN_MUTATION } from '@/lib/graphql';
+import { Button } from '@/components/ui/button';
+import { Input } from '@/components/ui/input';
+import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
 import { Eye, EyeOff, Shield } from 'lucide-react';
 
 export default function AdminLogin() {

--- a/client/app/dashboard/notifications/page.js
+++ b/client/app/dashboard/notifications/page.js
@@ -375,10 +375,10 @@
 
 import React, { useState } from "react";
 import { useQuery, useMutation } from "@apollo/client";
-import { GET_ALL_NOTIFICATIONS_QUERY, MARK_NOTIFICATION_AS_READ_MUTATION, MARK_ALL_NOTIFICATIONS_AS_READ } from "../../src/lib/graphql";
-import { Card, CardContent, CardHeader, CardTitle } from "../../src/components/ui/card";
-import { Button } from "../../src/components/ui/button";
-import { Input } from "../../src/components/ui/input";
+import { GET_ALL_NOTIFICATIONS_QUERY, MARK_NOTIFICATION_AS_READ_MUTATION, MARK_ALL_NOTIFICATIONS_AS_READ } from "@/lib/graphql";
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
 import {
   Bell,
   Search,

--- a/client/app/dashboard/page.js
+++ b/client/app/dashboard/page.js
@@ -3,8 +3,8 @@
 
 import React from 'react';
 import { useQuery } from '@apollo/client';
-import { GET_VISA_APPLICATIONS, GET_ADMIN_ME_QUERY } from '../../lib/graphql';
-import { Card, CardContent, CardHeader, CardTitle } from '../src/components/ui/card';
+import { GET_VISA_APPLICATIONS, GET_ADMIN_ME_QUERY } from '@/lib/graphql';
+import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
 import {
   FileText,
   Users,

--- a/client/app/dashboard/payments/page.js
+++ b/client/app/dashboard/payments/page.js
@@ -7,10 +7,10 @@ import {
   GET_PAYMENTS, 
   UPDATE_PAYMENT, 
   GENERATE_INVOICE 
-} from '../../src/lib/graphql';
-import { Card, CardContent, CardHeader, CardTitle } from '../../src/components/ui/card';
-import { Button } from '../../src/components/ui/button';
-import { Badge } from '../../src/components/ui/badge';
+} from '@/lib/graphql';
+import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
+import { Button } from '@/components/ui/button';
+import { Badge } from '@/components/ui/badge';
 import {
   CreditCard,
   FileText,

--- a/client/app/dashboard/pricing/PricingManagement.js
+++ b/client/app/dashboard/pricing/PricingManagement.js
@@ -3,8 +3,8 @@
 import { useState, useEffect } from "react";
 import { useQuery, useMutation } from "@apollo/client";
 import { PlusIcon, PencilIcon, TrashIcon, BanknotesIcon, CurrencyDollarIcon, GlobeAltIcon, ClockIcon, UserGroupIcon, BuildingOfficeIcon } from "@heroicons/react/24/outline";
-import { GET_ALL_PRICING_DATA } from "../../src/lib/graphql";
-import { DELETE_E_VISA_PRICE, DELETE_VISA_RUN_PRICE, DELETE_FAST_TRACK_PRICE } from "../../src/lib/graphql";
+import { GET_ALL_PRICING_DATA } from "@/lib/graphql";
+import { DELETE_E_VISA_PRICE, DELETE_VISA_RUN_PRICE, DELETE_FAST_TRACK_PRICE } from "@/lib/graphql";
 import PricingModal from "./PricingModal";
 
 export default function PricingManagement() {

--- a/client/app/dashboard/pricing/PricingModal.js
+++ b/client/app/dashboard/pricing/PricingModal.js
@@ -3,7 +3,7 @@
 import { useState, useEffect } from "react";
 import { useMutation } from "@apollo/client";
 import { XMarkIcon } from "@heroicons/react/24/outline";
-import { CREATE_E_VISA_PRICE, UPDATE_E_VISA_PRICE, CREATE_VISA_RUN_PRICE, UPDATE_VISA_RUN_PRICE, CREATE_FAST_TRACK_PRICE, UPDATE_FAST_TRACK_PRICE } from "../../src/lib/graphql";
+import { CREATE_E_VISA_PRICE, UPDATE_E_VISA_PRICE, CREATE_VISA_RUN_PRICE, UPDATE_VISA_RUN_PRICE, CREATE_FAST_TRACK_PRICE, UPDATE_FAST_TRACK_PRICE } from "@/lib/graphql";
 
 export default function PricingModal({
   isOpen,

--- a/client/app/dashboard/pricing/page.js
+++ b/client/app/dashboard/pricing/page.js
@@ -1,7 +1,7 @@
 "use client";
 
 import { useState } from "react";
-import ProtectedRoute from "../../../app/src/components/auth/ProtectedRoute";
+import ProtectedRoute from "@/components/auth/ProtectedRoute";
 import PricingManagement from "./PricingManagement";
 
 export default function PricingPage() {

--- a/client/app/dashboard/reports/page.js
+++ b/client/app/dashboard/reports/page.js
@@ -2,8 +2,8 @@
 'use client';
 
 import React, { useState } from 'react';
-import { Card, CardContent, CardHeader, CardTitle } from '../../src/components/ui/card';
-import { Button } from '../../src/components/ui/button';
+import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
+import { Button } from '@/components/ui/button';
 import { 
   BarChart3,
   TrendingUp,

--- a/client/app/dashboard/services/ServicesManagement.js
+++ b/client/app/dashboard/services/ServicesManagement.js
@@ -3,9 +3,9 @@
 import { useState } from "react";
 import { useQuery, useMutation } from "@apollo/client";
 import { Plus, Edit, Eye, Search } from "lucide-react";
-import { GET_ALL_PRICING_DATA } from "../../src/lib/graphql";
-import { GET_ADMIN_ME_QUERY } from "../../src/lib/graphql";
-import { CREATE_E_VISA_PRICE, UPDATE_E_VISA_PRICE, CREATE_VISA_RUN_PRICE, UPDATE_VISA_RUN_PRICE, CREATE_FAST_TRACK_PRICE, UPDATE_FAST_TRACK_PRICE } from "../../src/lib/graphql";
+import { GET_ALL_PRICING_DATA } from "@/lib/graphql";
+import { GET_ADMIN_ME_QUERY } from "@/lib/graphql";
+import { CREATE_E_VISA_PRICE, UPDATE_E_VISA_PRICE, CREATE_VISA_RUN_PRICE, UPDATE_VISA_RUN_PRICE, CREATE_FAST_TRACK_PRICE, UPDATE_FAST_TRACK_PRICE } from "@/lib/graphql";
 import ServiceModal from "./ServiceModal";
 
 export default function ServicesManagement() {

--- a/client/app/dashboard/services/page.js
+++ b/client/app/dashboard/services/page.js
@@ -3,7 +3,7 @@
 import { useState, useEffect } from "react";
 import { useRouter } from "next/navigation";
 import { useQuery } from "@apollo/client";
-import { GET_ADMIN_ME_QUERY } from "../../src/lib/graphql";
+import { GET_ADMIN_ME_QUERY } from "@/lib/graphql";
 import ServicesManagement from "./ServicesManagement";
 
 export default function ServicesPage() {

--- a/client/app/dashboard/settings/page.js
+++ b/client/app/dashboard/settings/page.js
@@ -2,9 +2,9 @@
 'use client';
 
 import React, { useState } from 'react';
-import { Card, CardContent, CardHeader, CardTitle } from '../../src/components/ui/card';
-import { Button } from '../../src/components/ui/button';
-import { Input } from '../../src/components/ui/input';
+import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
+import { Button } from '@/components/ui/button';
+import { Input } from '@/components/ui/input';
 import { 
   Settings,
   Bell,

--- a/client/app/dashboard/socket-test/page.js
+++ b/client/app/dashboard/socket-test/page.js
@@ -2,10 +2,10 @@
 
 import React, { useState, useEffect } from 'react';
 import { useMutation, gql } from '@apollo/client';
-import useSocket from '../../src/hooks/useSocket';
-import NotificationCenter from '../../src/components/NotificationCenter';
-import { Button } from '../../src/components/ui/button';
-import { Card, CardContent, CardHeader, CardTitle } from '../../src/components/ui/card';
+import useSocket from '@/hooks/useSocket';
+import NotificationCenter from '@/components/NotificationCenter';
+import { Button } from '@/components/ui/button';
+import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
 
 const UPDATE_APPLICATION_STATUS = gql`
   mutation UpdateApplicationStatus($id: ID!, $status: ApplicationStatus!) {

--- a/client/app/dashboard/users/page.js
+++ b/client/app/dashboard/users/page.js
@@ -7,10 +7,10 @@ import {
   CREATE_ADMIN_MUTATION,
   UPDATE_ADMIN_ROLE_MUTATION,
   DEACTIVATE_ADMIN_MUTATION 
-} from '../../src/lib/graphql';
-import { Card, CardContent, CardHeader, CardTitle } from '../../src/components/ui/card';
-import { Button } from '../../src/components/ui/button';
-import { Input } from '../../src/components/ui/input';
+} from '@/lib/graphql';
+import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
+import { Button } from '@/components/ui/button';
+import { Input } from '@/components/ui/input';
 import { 
   Users, 
   Plus, 

--- a/client/app/dashboard/workflows/page.js
+++ b/client/app/dashboard/workflows/page.js
@@ -2,14 +2,14 @@
 
 import React, { useState, useEffect } from "react";
 import { useQuery, useMutation, gql } from "@apollo/client";
-import { CREATE_WORKFLOW_TEMPLATE } from "../../src/lib/graphql/mutation/workflows";
-import { Card, CardContent, CardHeader, CardTitle } from "../../src/components/ui/card";
-import { Button } from "../../src/components/ui/button";
-import { Badge } from "../../src/components/ui/badge";
+import { CREATE_WORKFLOW_TEMPLATE } from "@/lib/graphql/mutation/workflows";
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import { Button } from "@/components/ui/button";
+import { Badge } from "@/components/ui/badge";
 import { CheckSquare, Plus, Settings, Play, FileText, Zap, Trash, Clock } from "lucide-react";
 import { toast } from "react-hot-toast";
 
-import Seo from "../../src/lib/seo";
+import Seo from "@/lib/seo";
 import { useTranslation } from "react-i18next";
 import { v4 as uuidv4 } from "uuid";
 import PropTypes from "prop-types";


### PR DESCRIPTION
## Summary
- standardize imports in `/client/app/dashboard` to use path aliases

## Testing
- `npm run lint` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_684e5858c3f4832ba959b6d68e9180da