### PR TITLE
Fix missing apply form utilities

### DIFF
--- a/client/app/apply/_components/types.js
+++ b/client/app/apply/_components/types.js
@@ -1,0 +1,84 @@
+// Types and interfaces for the apply form
+
+export const VISA_TYPES = {
+  GENERAL: "general",
+  BUSINESS: "business",
+  TOURIST: "tourist",
+  TRANSIT: "transit",
+};
+
+export const PROCESSING_TYPES = {
+  STANDARD: "standard",
+  EXPRESS: "express",
+  URGENT: "urgent",
+};
+
+export const DOCUMENT_TYPES = {
+  PASSPORT: "passport",
+  PHOTO: "photo",
+  INVITATION: "invitation",
+  HOTEL_BOOKING: "hotel_booking",
+  FLIGHT_TICKET: "flight_ticket",
+};
+
+export const STEPS = {
+  SERVICE_SELECTION: 1,
+  PERSONAL_INFO: 2,
+  CONTACT_INFO: 3,
+  TRAVEL_INFO: 4,
+  DOCUMENT_UPLOAD: 5,
+  REVIEW: 6,
+  PAYMENT: 7,
+  CONFIRMATION: 8,
+};
+
+export const SERVICE_TYPES = {
+  E_VISA: "e_visa",
+  ARRIVAL_VISA: "arrival_visa",
+  VISA_RUN: "visa_run",
+};
+
+export const VISA_DURATION_TYPES = {
+  SINGLE_90: "single_90",
+  MULTIPLE_90: "multiple_90",
+};
+
+export const initialFormData = {
+  // Service Selection
+  serviceType: "e_visa",
+  visaDurationType: "single_90",
+  processingType: "standard",
+  
+  // Personal Information
+  firstName: "",
+  lastName: "",
+  birthDate: "",
+  nationality: "",
+  passportNumber: "",
+  passportExpiry: "",
+  gender: "",
+
+  // Contact Information
+  email: "",
+  phone: "",
+  address: "",
+  city: "",
+  country: "",
+
+  // Travel Information
+  visaType: "general",
+  entryDate: "",
+  exitDate: "",
+  purpose: "",
+  previousVisit: false,
+
+  // Documents
+  documents: [],
+
+  // Additional Services
+  additionalServices: [],
+
+  // Payment
+  paymentMethod: "",
+  agreementAccepted: false,
+};

--- a/client/app/apply/_components/utils.js
+++ b/client/app/apply/_components/utils.js
@@ -1,0 +1,93 @@
+// Utility functions for the apply form
+
+export const formatCurrency = (amount, currency = "KRW") => {
+  return new Intl.NumberFormat("ko-KR", {
+    style: "currency",
+    currency: currency,
+  }).format(amount);
+};
+
+export const formatDate = (date) => {
+  return new Date(date).toLocaleDateString("ko-KR");
+};
+
+export const validateEmail = (email) => {
+  const emailRegex = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
+  return emailRegex.test(email);
+};
+
+export const validatePhone = (phone) => {
+  const phoneRegex = /^[\d\-\+\(\)\s]+$/;
+  return phoneRegex.test(phone) && phone.length >= 10;
+};
+
+export const validatePassport = (passport) => {
+  return passport.length >= 6 && passport.length <= 12;
+};
+
+export const calculateVisaPrice = (visaType, processingType) => {
+  const basePrices = {
+    general: 25000,
+    business: 35000,
+    tourist: 20000,
+    transit: 15000,
+  };
+
+  const processingMultipliers = {
+    standard: 1,
+    express: 1.5,
+    urgent: 2,
+  };
+
+  const basePrice = basePrices[visaType] || basePrices.general;
+  const multiplier = processingMultipliers[processingType] || 1;
+
+  return Math.round(basePrice * multiplier);
+};
+
+export const getStepTitle = (step) => {
+  const titles = {
+    1: "서비스 선택",
+    2: "개인정보 입력",
+    3: "연락처 정보",
+    4: "여행 정보",
+    5: "서류 업로드",
+    6: "신청 내용 확인",
+    7: "결제",
+    8: "신청 완료"
+  };
+  return titles[step] || `단계 ${step}`;
+};
+
+export const getStepDescription = (step) => {
+  const descriptions = {
+    1: "원하시는 서비스를 선택해주세요",
+    2: "개인정보를 입력해주세요",
+    3: "연락처 정보를 입력해주세요", 
+    4: "여행 정보를 입력해주세요",
+    5: "필수 서류를 업로드해주세요",
+    6: "입력하신 정보를 확인해주세요",
+    7: "결제를 진행해주세요",
+    8: "신청이 완료되었습니다"
+  };
+  return descriptions[step] || "";
+};
+
+export const validateStep = (step, formData) => {
+  switch (step) {
+    case 1:
+      return formData.firstName && formData.lastName && formData.birthDate && formData.nationality && formData.passportNumber && formData.passportExpiry && formData.gender;
+    case 3:
+      return formData.email && formData.phone && formData.address && validateEmail(formData.email) && validatePhone(formData.phone);
+    case 4:
+      return formData.visaType && formData.processingType && formData.entryDate && formData.purpose;
+    case 5:
+      return formData.documents && formData.documents.length >= 2; // passport + photo minimum
+    case 6:
+      return true; // Review step
+    case 7:
+      return formData.paymentMethod && formData.agreementAccepted;
+    default:
+      return false;
+  }
+};


### PR DESCRIPTION
## Summary
- restore `initialFormData` definitions and validation helpers for visa application

## Testing
- `npm run lint` *(fails: prompts for ESLint config)*
- `npm run build` *(fails: module not found)*

------
https://chatgpt.com/codex/tasks/task_e_684e60b69228832b8678d1d8d5c063eb